### PR TITLE
fix disabling when profile has changed

### DIFF
--- a/GridStatusHealTrace.lua
+++ b/GridStatusHealTrace.lua
@@ -216,6 +216,9 @@ function GridStatusHealTrace:PostReset()
 			self:AddSpell(name, icon)
 		end
 	end
+	if self.db.profile.alert_healTrace.enable then
+		self:RegisterEvent("SPELLS_CHANGED", "OnStatusEnable")
+	end
 end
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
When grid profile has changed, reset function makes healtrace disabled so I fixed