### PR TITLE
Fixed broken COMBAT_LOG_EVENT_UNFILTERED function

### DIFF
--- a/GridStatusHealTrace.lua
+++ b/GridStatusHealTrace.lua
@@ -242,8 +242,8 @@ timerFrame:SetScript("OnUpdate", function(self, elapsed)
 	end
 end)
 
-function GridStatusHealTrace:COMBAT_LOG_EVENT_UNFILTERED(_, _, event)
-	local _, sourceGUID, sourceName, _, _, destGUID, destName, _, _, spellID, spellName = CombatLogGetCurrentEventInfo()
+function GridStatusHealTrace:COMBAT_LOG_EVENT_UNFILTERED()
+	local _, event, _, sourceGUID, sourceName, _, _, destGUID, destName, _, _, spellID, spellName = CombatLogGetCurrentEventInfo()
 	if sourceGUID ~= playerGUID or event ~= "SPELL_HEAL" or not spells[spellName] then
 		return
 	end


### PR DESCRIPTION
I'm not sure how long ago this broke as I haven't played my healer since Legion. But GridStatusHealTrace didn't function when I tried it today. Some digging around showed that the COMBAT_LOG_EVENT_UNFILTERED function was returning incorrect info.

The COMBAT_LOG_EVENT_UNFILTERED function now returns the correct info and the addon works once again.